### PR TITLE
Improved default hash function for memoize()

### DIFF
--- a/test/FunctionsTest.php
+++ b/test/FunctionsTest.php
@@ -50,6 +50,11 @@ class UnderscoreFunctionsTest extends PHPUnit_Framework_TestCase {
     };
     $fastFibonacci = __::memoize($fibonacci);
     $this->assertEquals($fibonacci(2), $fastFibonacci(2));
+    
+    $fastFoo = __::memoize($foo);
+    $fastBar = __::memoize($bar);
+    
+    $this->assertNotEquals($fastFoo(), $fastBar(), 'can handle different closures');
   }
   
   public function testThrottle() {

--- a/underscore.php
+++ b/underscore.php
@@ -966,9 +966,20 @@ class __ {
       $args = func_get_args();
       if(is_null($hashFunction)) $hashFunction = function($function, $args) {
         
+        // array callback
+        if(is_array($function) && is_object($function[0])) {
+          $hash = spl_object_hash($function[0]).'::'.$function[1];
+        }
+        else if(is_object($function)) {
+          $hash = spl_object_hash($function);
+        }
+        else {
+          $hash = var_export($function, true);
+        }
+        
         // Try using var_export to identify the function
         return md5(join('_', array(
-          var_export($function, true),
+          $hash,
           var_export($args, true)
         )));
       };


### PR DESCRIPTION
I've improved the implementation of default hash function in memoize(). It should be able to recognize callbacks from different objects.