### PR TITLE
Added function for partial application

### DIFF
--- a/test/FunctionsTest.php
+++ b/test/FunctionsTest.php
@@ -193,4 +193,16 @@ class UnderscoreFunctionsTest extends PHPUnit_Framework_TestCase {
     $func();
     $this->assertEquals('x', $str);
   }
+
+  function testPartial() {
+      // partial once
+      $f = function( $x, $y ) { return $x + $y; };
+      $f2 = __::partial( $f, 2 );
+      $this->assertEquals( 5, $f2(3) );
+
+      // partial on a partial
+      $f3 = __::partial( $f2, 4 );
+      $this->assertEquals( 6, $f3() );
+  }
+
 }

--- a/underscore.php
+++ b/underscore.php
@@ -1069,6 +1069,17 @@ class __ {
     };
     return self::_wrap(($count) ? $func : $func());
   }
+
+
+  // creates a partially applied version of the function
+  public function partial() {
+      $origArgs = func_get_args();
+      $f = array_shift( $origArgs );
+      return function() use ( $f, $origArgs ) {
+          $allArgs = array_merge( $origArgs, func_get_args() );
+          return call_user_func_array( $f, $allArgs );
+      };
+  }
   
   
   // Singleton


### PR DESCRIPTION
bind/unbind obviously don't port to PHP as there is no function scope as such, so this provides partial application without the Javascript scoping of bind/unbind in underscore.js
