### PR TITLE
Fix: compose was composing functions in the wrong order

### DIFF
--- a/test/FunctionsTest.php
+++ b/test/FunctionsTest.php
@@ -141,16 +141,16 @@ class UnderscoreFunctionsTest extends PHPUnit_Framework_TestCase {
   public function testCompose() {
     // from js
     $greet = function($name) { return 'hi: ' . $name; };
-    $exclaim = function($sentence) { return $sentence . '!'; };
+    $exclaim = function($sentence) { return strtoupper($sentence) . '!'; };
     $composed = __::compose($exclaim, $greet);
-    $this->assertEquals('hi: moe!', $composed('moe'), 'can compose a function that takes another');
+    $this->assertEquals('HI: MOE!', $composed('moe'), 'can compose a function that takes another');
     
     $composed = __::compose($greet, $exclaim);
-    $this->assertEquals('hi: moe!', $composed('moe'), 'in this case, the functions are also commutative');
+    $this->assertEquals('hi: MOE!', $composed('moe'), 'composes functions in the proper order');
     
     // extra
     $composed = __($greet)->compose($exclaim);
-    $this->assertEquals('hi: moe!', $composed('moe'), 'in this case, the functions are also commutative');
+    $this->assertEquals('hi: MOE!', $composed('moe'), 'can chain compose calls');
   
     // docs
     $greet = function($name) { return 'hi: ' . $name; };

--- a/underscore.php
+++ b/underscore.php
@@ -1045,7 +1045,7 @@ class __ {
     
     return self::_wrap(function() use ($functions) {
       $args = func_get_args();
-      foreach($functions as $function) {
+      foreach(array_reverse($functions) as $function) {
         $args[0] = call_user_func_array($function, $args);
       }
       return $args[0];


### PR DESCRIPTION
Here's a fix for the fact that compose was composing functions in the wrong order, and modified test cases to test for it.

Previously `__::compose($f, $g)` would return a function `$h` such that `$h($x) = $g($f($x)`.

Instead `__::compose($f, $g)` should return a function `$h` such that `$h($x) = $f($g($x)`.

This is more consistent with the behavior of Underscore.js and is also closer to mathematical conventions.
